### PR TITLE
Update to avoid client error

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,0 +1,1 @@
+// On the client we do nothing

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
 	name: 'riffyn:set-connection-options',
-	version: '0.0.2',
+	version: '0.0.3',
 	// Brief, one-line summary of the package.
 	summary: 'Set mongo connection setting ignoreUndefined to false',
 	// URL to the Git repository containing the source code for this package.
@@ -16,7 +16,8 @@ Package.onUse(function (api) {
 	api.use('meteor');
 	api.use('mongo');
 	api.use('npm-mongo');
-	api.mainModule('set-connection-options.js');
+	api.mainModule('server.js', 'server');
+	api.mainModule('client.js', 'client');
 });
 
 Package.onTest(function (api) {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,4 @@
+import { Mongo } from 'meteor/mongo';
+
+console.log("Setting Mongo connection options to {ignoreUndefined: false}");
+Mongo.setConnectionOptions({ ignoreUndefined: false });

--- a/set-connection-options.js
+++ b/set-connection-options.js
@@ -1,7 +1,0 @@
-// Write your package code here!
-
-import { Mongo } from 'meteor/mongo';
-// Variables exported by this module can be imported by other packages and
-// applications. See set-connection-options-tests.js for an example of importing.
-
-Mongo.setConnectionOptions({ ignoreUndefined: false });


### PR DESCRIPTION
Previously we were doing Mongo.setConnectionOptions always, but this
function is not defined on the client and so was producing an error.
This patch adds separate server.js and client.js files to prevent this.